### PR TITLE
feat: Update GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Set up Node.js with Node v22 and install pnpm
       - uses: actions/setup-node@v4
         with:
-          node-version: 22  # Update to Node.js v22
+          node-version: 22 
           cache: 'pnpm'
 
       # Install pnpm (latest compatible version)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install and setup pnpm
-      - uses: pnpm/action-setup@v2.2.1
-        with:
-          version: 7.0 # specify the pnpm version
-
-      # Setup Node.js and cache pnpm
+      # Set up Node.js with Node v22 and install pnpm
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22  # Update to Node.js v22
           cache: 'pnpm'
+
+      # Install pnpm (latest compatible version)
+      - name: Install pnpm
+        run: npm install -g pnpm@9.12.2  
 
       # Install dependencies
       - name: Install Dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,10 +28,10 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build Project
-        run: pnpm exec nx build riffroll-app --prod
+        run: pnpm exec nx build riffroll --prod
 
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: dist/apps/riffroll-app
+          publish_dir: dist/apps/riffroll

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install pnpm and dependencies
+        uses: pnpm/action-setup@v2.2.1
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build Project
+        run: pnpm exec nx build riffroll-app --prod
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist/apps/riffroll-app


### PR DESCRIPTION
This pull request updates the GitHub Pages deployment workflow for the riffroll app. The build command in the workflow has been changed to build the "riffroll" app instead of "riffroll-app". Additionally, the publish directory has been updated to deploy the built app to the correct location.